### PR TITLE
Accept capitalized Project in metadata

### DIFF
--- a/src/createCurriculumManifest/metadata.js
+++ b/src/createCurriculumManifest/metadata.js
@@ -73,7 +73,7 @@ var setMetadataFromMarkdown = function(node, attributes) {
     /* TODO(olex): This is the only case where markdown overrides structure.xml
      *             Switch to <project> tags instead of <assignment>
      */
-    if (/project/.test(attributes.type)) {
+    if (/[Pp]roject/.test(attributes.type)) {
         node.type = "project";
     }
 }


### PR DESCRIPTION
Files with `type: Project` currently don't show up as projects because of the capitalization.  This fix updates the regex to accept both `type: project` and `type: Project`.  See https://github.com/Thinkful-Ed/curric-node-001-v4/issues/16 for an example issue which would be fixed by this without needing updates to the metadata.